### PR TITLE
Remove PCH

### DIFF
--- a/thumborurl.xcodeproj/project.pbxproj
+++ b/thumborurl.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 /* Begin PBXFileReference section */
 		F69614F5153C933E00AC1F5C /* libthumborurl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libthumborurl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F69614F8153C933E00AC1F5C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		F69614FC153C933E00AC1F5C /* thumborurl-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "thumborurl-Prefix.pch"; sourceTree = "<group>"; };
 		F6961509153C940000AC1F5C /* ThumborURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThumborURL.h; sourceTree = "<group>"; };
 		F696150A153C940000AC1F5C /* ThumborURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThumborURL.m; sourceTree = "<group>"; };
 		F6EC7490153CB63C00AF55B4 /* thumborurltests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = thumborurltests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -96,19 +95,10 @@
 		F69614FA153C933E00AC1F5C /* thumborurl */ = {
 			isa = PBXGroup;
 			children = (
-				F69614FB153C933E00AC1F5C /* Supporting Files */,
 				F6961509153C940000AC1F5C /* ThumborURL.h */,
 				F696150A153C940000AC1F5C /* ThumborURL.m */,
 			);
 			path = thumborurl;
-			sourceTree = "<group>";
-		};
-		F69614FB153C933E00AC1F5C /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				F69614FC153C933E00AC1F5C /* thumborurl-Prefix.pch */,
-			);
-			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		F6EC7496153CB63C00AF55B4 /* thumborurltests */ = {
@@ -324,8 +314,6 @@
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/thumborurl.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "thumborurl/thumborurl-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -341,8 +329,6 @@
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/thumborurl.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "thumborurl/thumborurl-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/thumborurl/ThumborURL.h
+++ b/thumborurl/ThumborURL.h
@@ -10,6 +10,7 @@
 //
 
 #import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
 
 
 @class TUFilter;

--- a/thumborurl/thumborurl-Prefix.pch
+++ b/thumborurl/thumborurl-Prefix.pch
@@ -1,7 +1,0 @@
-//
-// Prefix header for all source files of the 'thumborurl' target in the 'thumborurl' project
-//
-
-#ifdef __OBJC__
-    #import <Foundation/Foundation.h>
-#endif


### PR DESCRIPTION
PCH files are no longer recommended by clang docs and have a tendency to cause build errors. In practice they also tend to slow builds down.