### PR TITLE
Properly URI encode image URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-osx_image: xcode6.4
+osx_image: xcode10.2
 script:
     - xcodebuild -project thumborurl.xcodeproj -scheme thumborurl -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test

--- a/README.md
+++ b/README.md
@@ -16,29 +16,64 @@ A library to generate encrypted URLs for [Thumbor](https://github.com/thumbor/th
 	* Trim
 * Performs quickly
 
-## Usage
+## Installation
 
-1. Add `https://github.com/square/ThumborURL.git` as a submodule of your project
+### Cocoapods
+
+1. Add `pod ThumborURL` to your Podfile.
+1. `pod install`
+1. `import ThumborURL` (Swift) or `@import ThumborURL;` (Objective-C).
+
+### Manually
+
+1. Add `https://github.com/square/ThumborURL.git` as a submodule of your project.
 1. Add `thumborurl.xcodeproj` as a subproject of your Xcode project.
 1. Make the `thumborurl` library a dependency of your target.
 1. Link the `thumborurl` library to your target.
 1. `#import <thumborurl/ThumborURL.h>`
 
-## Examples
+## Usage
 
-    TUOptions *opts = [[TUOptions alloc] init];
+### Swift
 
-    NSURL *imageURL = [NSURL URLWithString:@"twitter.com/foo.png"];
-    NSURL *baseURL = [NSURL URLWithString:@"http://images.example.com"];
-    NSString *key = @"omg152";
+```swift
+let imageURL = URL(string: "twitter.com/foo.png")!
+let baseURL = URL(string: "http://images.example.com")!
+let securityKey = "omg152"
 
-    opts.crop = CGRectMake(20, 20, 20, 20);
-    opts.smart = YES;
-    opts.targetSize = CGSizeMake(10, 10);
-    opts.fitIn = TUFitInNormal;
-    opts.vflip = YES;
-    opts.filters = @[[TUFilter filterWithName:@"watermark" arguments:@"blah.png", @"10", @"20", @"30", nil],
-                     [TUFilter filterWithName:@"watermark" arguments:@"baz.png", @"4", @"8", @"15", nil]];
+let options = TUOptions()
+options.crop = CGRect(x: 10, y: 10, width: 10, height: 10)
+options.smart = true
+options.targetSize = CGSize(width: 10, height: 10)
+options.fitIn = .normal
+options.vflip = true
+options.filters = [
+    TUFilter(name: "watermark", argumentsArray: ["blah.png", "10", "20", "30"]),
+    TUFilter(name: "watermark", argumentsArray: ["baz.png", "4", "8", "5"])
+]
 
-    NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    // u is http://images.example.com/aOH7-AuI2kyIb4d9TLbcBdDlGwk=/20x20:40x40/fit-in/10x-10/smart/twitter.com/foo.png
+let thumborImageURL = NSURL.tu_secureURL(with: options, imageURL: imageURL, baseURL: baseURL, securityKey: securityKey)
+
+// thumborImageURL = "http://images.example.com/9sG5VMXh7HoCgPlNH8AZx42y4fc=/10x10:20x20/fit-in/10x-10/smart/filters:watermark(blah.png,10,20,30):watermark(baz.png,4,8,5)/twitter.com/foo.png"
+```
+
+### Objective-C
+
+```objective-c
+TUOptions *opts = [[TUOptions alloc] init];
+
+NSURL *imageURL = [NSURL URLWithString:@"twitter.com/foo.png"];
+NSURL *baseURL = [NSURL URLWithString:@"http://images.example.com"];
+NSString *key = @"omg152";
+
+opts.crop = CGRectMake(20, 20, 20, 20);
+opts.smart = YES;
+opts.targetSize = CGSizeMake(10, 10);
+opts.fitIn = TUFitInNormal;
+opts.vflip = YES;
+opts.filters = @[[TUFilter filterWithName:@"watermark" arguments:@"blah.png", @"10", @"20", @"30", nil],
+                 [TUFilter filterWithName:@"watermark" arguments:@"baz.png", @"4", @"8", @"15", nil]];
+
+NSURL *thumborImageURL = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
+// thumborImageURL is http://images.example.com/9sG5VMXh7HoCgPlNH8AZx42y4fc=/10x10:20x20/fit-in/10x-10/smart/filters:watermark(blah.png,10,20,30):watermark(baz.png,4,8,5)/twitter.com/foo.png
+```

--- a/thumborurl.xcodeproj/project.pbxproj
+++ b/thumborurl.xcodeproj/project.pbxproj
@@ -158,7 +158,6 @@
 				F6EC748B153CB63C00AF55B4 /* Sources */,
 				F6EC748C153CB63C00AF55B4 /* Frameworks */,
 				F6EC748D153CB63C00AF55B4 /* Resources */,
-				F6EC748E153CB63C00AF55B4 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -206,22 +205,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		F6EC748E153CB63C00AF55B4 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		F69614F1153C933E00AC1F5C /* Sources */ = {

--- a/thumborurl/ThumborURL.h
+++ b/thumborurl/ThumborURL.h
@@ -47,8 +47,8 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 /// If no key is specified, a key per image is required.
 @interface TUEndpointConfiguration : NSObject
 
-- (id)initWithBaseURL:(NSURL *)baseURL securityKey:(NSString *)securityKey;
-- (id)initWithBaseURL:(NSURL *)baseURL;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL securityKey:(NSString *)securityKey;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL;
 
 @property (nonatomic, copy) NSURL *baseURL;
 @property (nonatomic, copy) NSString *globalSecurityKey;
@@ -85,7 +85,7 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 @property (nonatomic, assign) BOOL vflip;
 @property (nonatomic, assign) BOOL hflip;
 
-@property (nonatomic, copy) NSArray *filters;
+@property (nonatomic, copy) NSArray<TUFilter *> *filters;
 
 @property (nonatomic, assign) CGFloat scale;
 
@@ -99,15 +99,15 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic, copy) NSArray *arguments;
 
-+ (id)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
-+ (id)filterWithName:(NSString *)name arguments:(id)firstArg, ... NS_REQUIRES_NIL_TERMINATION;
++ (instancetype)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
++ (instancetype)filterWithName:(NSString *)name arguments:(id)firstArg, ... NS_REQUIRES_NIL_TERMINATION;
 
 @end
 
 
 @interface NSURL (ThumborURL)
 
-+ (id)TU_secureURLWithOptions:(TUOptions *)options imageURL:(NSURL *)imageURL baseURL:(NSURL *)baseURL securityKey:(NSString *)securityKey;
++ (instancetype)TU_secureURLWithOptions:(TUOptions *)options imageURL:(NSURL *)imageURL baseURL:(NSURL *)baseURL securityKey:(NSString *)securityKey;
 
 @property (nonatomic, assign, readonly, getter=isThumborizableURL) BOOL thumborizableURL;
 @property (nonatomic, assign, readonly, getter=isThumborizedURL) BOOL thumborizedURL;

--- a/thumborurl/ThumborURL.m
+++ b/thumborurl/ThumborURL.m
@@ -373,11 +373,18 @@ static NSString *const TUIsThumborizedURLKey = @"TUIsThumborizedURL";
 
 #pragma mark - Private Methods
 
+/*
+ Thumbor uses Python's `quote()` and `unquote()` functions from `urllib` for encoding/decoding URIs. The documentation
+ for those functions at <https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote> indicates the reserved
+ characters are: _ . - ~ /
+
+ This behavior was verified as correct by inputting various URLs into the `thumbor-url` command-line tool.
+ */
 - (nullable NSString *)_encodedURIString;
 {
     NSMutableCharacterSet *const allowedCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
 
-    NSString *const unreservedCharacters = @"-._";
+    NSString *const unreservedCharacters = @"_.-~/";
     [allowedCharacters addCharactersInString:unreservedCharacters];
 
     return [self.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];

--- a/thumborurl/ThumborURL.m
+++ b/thumborurl/ThumborURL.m
@@ -292,17 +292,13 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
 
 static NSString *const TUIsThumborizedURLKey = @"TUIsThumborizedURL";
 
+#pragma mark - Class Methods
+
 + (id)TU_secureURLWithOptions:(TUOptions *)options imageURL:(NSURL *)imageURL baseURL:(NSURL *)baseURL securityKey:(NSString *)securityKey;
 {
     NSAssert(securityKey.length > 0, @"securityKey required");
 
-    // Remove the query from calculating the hash.
-    NSString *imageURLString = imageURL.absoluteString;
-
-    NSString *query = imageURL.query;
-    if (query != nil) {
-        imageURLString = [imageURLString substringToIndex:imageURLString.length - (query.length + 1)];
-    }
+    NSString *const imageURLString = [imageURL _encodedURIString];
 
     // Encrypt URL based declared encryption scheme.
     NSString *suffix = nil;
@@ -315,16 +311,12 @@ static NSString *const TUIsThumborizedURLKey = @"TUIsThumborizedURL";
 
         case TUEncryptionModeHMACSHA1:
         default: {
-            // It is important not to generate the URL by using stringByAppendingPathComponent because the trimmedString is not
-            // a filesystem path component. As such, http://lol gets turned into http:/lol by the API which 
-            // Thumbor will then reject causing all images in our app which use Thumbor to stop loading :)
-            NSString *trimmedString = [imageURLString stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
             NSString *optionsString = options.URLOptionsPath;
             
             if (optionsString.length) {
-                suffix = [NSString stringWithFormat:@"%@/%@", optionsString, trimmedString];
+                suffix = [NSString stringWithFormat:@"%@/%@", optionsString, imageURLString];
             } else {
-                suffix = trimmedString;
+                suffix = imageURLString;
             }
             
             result = TUCreateEncryptedHMACSHA1Data(suffix, securityKey);
@@ -377,6 +369,18 @@ static NSString *const TUIsThumborizedURLKey = @"TUIsThumborizedURL";
     const NSNumber *isThumborizedURL = objc_getAssociatedObject(self, (__bridge void *)TUIsThumborizedURLKey);
 
     return isThumborizedURL.boolValue;
+}
+
+#pragma mark - Private Methods
+
+- (nullable NSString *)_encodedURIString;
+{
+    NSMutableCharacterSet *const allowedCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
+
+    NSString *const unreservedCharacters = @"-._";
+    [allowedCharacters addCharactersInString:unreservedCharacters];
+
+    return [self.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
 @end

--- a/thumborurltests/ThumborURLTests.m
+++ b/thumborurltests/ThumborURLTests.m
@@ -31,7 +31,7 @@
     opts.encryption = TUEncryptionModeAES128;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/eTrNUjZAdPXHgX399jB3R7P9X4-1oWhkAEh-0M3BkRH_SdZjMBjxidWR6hdR-9cy/http%3A%2F%2Ftwitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/fc_GrmvCFNnByKJG8XmdZh-ioMJKM5JAaGJX8mxH9JvH2KeTq3JOeC1is_b4lgAE/http%3A//twitter.com/foo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should work");
 }
@@ -51,8 +51,8 @@
     opts.encryption = TUEncryptionModeAES128;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIjoB7ht7ZpckOEQH4-hixLgCdgff6-RuZarmjLiCLmBeUAcPDtZLd9yOw5FJUag7xA==/http%3A%2F%2Ftwitter.com%2Ffoo.png";
-    
+    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIgvRjXnaBQfUDEDsKLINf9GDhOuTv8FegBLJ2fAuuJDUY-8X7yCFwMTYJVT22XlWKQ==/http%3A//twitter.com/foo.png";
+
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
 
@@ -72,7 +72,7 @@
     opts.encryption = TUEncryptionModeAES128;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIjoB7ht7ZpckOEQH4-hixLgCdgff6-RuZarmjLiCLmBeUAcPDtZLd9yOw5FJUag7xA==/http%3A%2F%2Ftwitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIgvRjXnaBQfUDEDsKLINf9GDhOuTv8FegBLJ2fAuuJDUY-8X7yCFwMTYJVT22XlWKQ==/http%3A//twitter.com/foo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -99,7 +99,7 @@
     opts.vflip = NO;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:newOpts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIjoB7ht7ZpckOEQH4-hixLgCdgff6-RuZarmjLiCLmBeUAcPDtZLd9yOw5FJUag7xA==/http%3A%2F%2Ftwitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIgvRjXnaBQfUDEDsKLINf9GDhOuTv8FegBLJ2fAuuJDUY-8X7yCFwMTYJVT22XlWKQ==/http%3A//twitter.com/foo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -118,7 +118,7 @@
     opts.encryption = TUEncryptionModeAES128;
 
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/ntizt-ZKGa7YNJLoTH7ie6wGXkyJxdzrcqOrtGvhyMQI12qTMRWYGqAki7QTt6miN5WRN16TZCIywyE9EJnnSLGdsg3TKHsj_OHHfZpTMNwu1zn2Yyl-bUzIclN10AVg/http%3A%2F%2Ftwitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/ntizt-ZKGa7YNJLoTH7ie6wGXkyJxdzrcqOrtGvhyMQI12qTMRWYGqAki7QTt6mi3A-iGEEhSaeCCalXhun6gO_N8IDt5gCt_E17K0tBd3mdx5EFnjJsqEsTvuOXzjLH/http%3A//twitter.com/foo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");    
 }
@@ -132,7 +132,7 @@
     NSString *key = @"omg152";
 
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/-aCOyqtbVcIbP_7O4QTFkuOI3V4=/twitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/yfI2JhRv0z312pPzm_vE6U4cURM=/twitter.com/foo.png";
 
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should work");
 }
@@ -152,7 +152,7 @@
     opts.vflip = YES;
 
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/4UlktUO-rV0rJOq8vUjcK8CvXmA=/20x20:40x40/fit-in/10x-10/smart/twitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/aOH7-AuI2kyIb4d9TLbcBdDlGwk=/20x20:40x40/fit-in/10x-10/smart/twitter.com/foo.png";
 
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -172,7 +172,7 @@
     opts.vflip = YES;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/QwlNpTi0S_yJAneCEjZubFEMKOQ=/20x20:40x40/full-fit-in/10x-10/smart/twitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/pe1aHRMVLSs-f9lZd9o0RVjhEUY=/20x20:40x40/full-fit-in/10x-10/smart/twitter.com/foo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -208,10 +208,21 @@
     opts.vflip = YES;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/7aYGA6rz53JpoEMq3x2JvehTSf4=/trim/20x20:40x40/fit-in/10x-10/smart/twitter.com%2Ffoo.png";
+    NSString *expectedURL = @"/BmpHlSr72S8Xee7wZ-LCsENOu8Y=/trim/20x20:40x40/fit-in/10x-10/smart/twitter.com/foo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
 
+- (void)testQueryIsIncludedInURL;
+{
+    NSURL *const imageURL = [NSURL URLWithString:@"http://twitter.com/foo.png?optionA=1&optionB=2"];
+    NSURL *const baseURL = [NSURL URLWithString:@"http://images.example.com"];
+    NSString *const key = @"omg152";
+    
+    NSURL *const thumborImageURL = [NSURL TU_secureURLWithOptions:[TUOptions new] imageURL:imageURL baseURL:baseURL securityKey:key];
+    NSURL *const expectedURL = [NSURL URLWithString:@"http://images.example.com/HOWsZqvJmMVNoOZwD8JmxSBBMfE=/http%3A//twitter.com/foo.png%3FoptionA%3D1%26optionB%3D2"];
+    
+    XCTAssertEqualObjects(expectedURL.absoluteString, thumborImageURL.absoluteString, @"Should be equal and contain query items");
+}
 
 @end

--- a/thumborurltests/ThumborURLTests.m
+++ b/thumborurltests/ThumborURLTests.m
@@ -31,7 +31,7 @@
     opts.encryption = TUEncryptionModeAES128;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/qcQJp6JpxvDT799fxzjPYxt9A0ooZSeV_NOo-nC0-GN5kvKkWcTfpqwLE5PgFouD/http://twitter.com/foo.png";
+    NSString *expectedURL = @"/eTrNUjZAdPXHgX399jB3R7P9X4-1oWhkAEh-0M3BkRH_SdZjMBjxidWR6hdR-9cy/http%3A%2F%2Ftwitter.com%2Ffoo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should work");
 }
@@ -51,7 +51,7 @@
     opts.encryption = TUEncryptionModeAES128;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIj-IHwbA2IGyC7bPtNuPS4RvyMFh4I76UuuV6dNIjG9fV6FDVsTGF5sD23qD7sMwEg==/http://twitter.com/foo.png";
+    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIjoB7ht7ZpckOEQH4-hixLgCdgff6-RuZarmjLiCLmBeUAcPDtZLd9yOw5FJUag7xA==/http%3A%2F%2Ftwitter.com%2Ffoo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -72,7 +72,7 @@
     opts.encryption = TUEncryptionModeAES128;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIj-IHwbA2IGyC7bPtNuPS4RvyMFh4I76UuuV6dNIjG9fV6FDVsTGF5sD23qD7sMwEg==/http://twitter.com/foo.png";
+    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIjoB7ht7ZpckOEQH4-hixLgCdgff6-RuZarmjLiCLmBeUAcPDtZLd9yOw5FJUag7xA==/http%3A%2F%2Ftwitter.com%2Ffoo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -99,7 +99,7 @@
     opts.vflip = NO;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:newOpts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIj-IHwbA2IGyC7bPtNuPS4RvyMFh4I76UuuV6dNIjG9fV6FDVsTGF5sD23qD7sMwEg==/http://twitter.com/foo.png";
+    NSString *expectedURL = @"/VN-DQqsh6mSk4bb6biPlIjoB7ht7ZpckOEQH4-hixLgCdgff6-RuZarmjLiCLmBeUAcPDtZLd9yOw5FJUag7xA==/http%3A%2F%2Ftwitter.com%2Ffoo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -118,7 +118,7 @@
     opts.encryption = TUEncryptionModeAES128;
 
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/ntizt-ZKGa7YNJLoTH7ie6wGXkyJxdzrcqOrtGvhyMQI12qTMRWYGqAki7QTt6miJKiCzgSScrlxGoN_U7tbp_3TNgOmlJUfeoXtwnxQ26RxMT6HzFjuLShitTZ4u015/http://twitter.com/foo.png";
+    NSString *expectedURL = @"/ntizt-ZKGa7YNJLoTH7ie6wGXkyJxdzrcqOrtGvhyMQI12qTMRWYGqAki7QTt6miN5WRN16TZCIywyE9EJnnSLGdsg3TKHsj_OHHfZpTMNwu1zn2Yyl-bUzIclN10AVg/http%3A%2F%2Ftwitter.com%2Ffoo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");    
 }
@@ -132,7 +132,7 @@
     NSString *key = @"omg152";
 
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/yfI2JhRv0z312pPzm_vE6U4cURM=/twitter.com/foo.png";
+    NSString *expectedURL = @"/-aCOyqtbVcIbP_7O4QTFkuOI3V4=/twitter.com%2Ffoo.png";
 
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should work");
 }
@@ -152,7 +152,7 @@
     opts.vflip = YES;
 
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/aOH7-AuI2kyIb4d9TLbcBdDlGwk=/20x20:40x40/fit-in/10x-10/smart/twitter.com/foo.png";
+    NSString *expectedURL = @"/4UlktUO-rV0rJOq8vUjcK8CvXmA=/20x20:40x40/fit-in/10x-10/smart/twitter.com%2Ffoo.png";
 
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -172,7 +172,7 @@
     opts.vflip = YES;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/pe1aHRMVLSs-f9lZd9o0RVjhEUY=/20x20:40x40/full-fit-in/10x-10/smart/twitter.com/foo.png";
+    NSString *expectedURL = @"/QwlNpTi0S_yJAneCEjZubFEMKOQ=/20x20:40x40/full-fit-in/10x-10/smart/twitter.com%2Ffoo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }
@@ -208,7 +208,7 @@
     opts.vflip = YES;
     
     NSURL *u = [NSURL TU_secureURLWithOptions:opts imageURL:imageURL baseURL:baseURL securityKey:key];
-    NSString *expectedURL = @"/BmpHlSr72S8Xee7wZ-LCsENOu8Y=/trim/20x20:40x40/fit-in/10x-10/smart/twitter.com/foo.png";
+    NSString *expectedURL = @"/7aYGA6rz53JpoEMq3x2JvehTSf4=/trim/20x20:40x40/fit-in/10x-10/smart/twitter.com%2Ffoo.png";
     
     XCTAssertEqualObjects(expectedURL, u.relativeString, @"Should be equal to command line generated version");
 }


### PR DESCRIPTION
The previous logic for Thumbor URL generation did not previously correctly encode URLs with query path in the source image path. It incorrectly removed the query path from the URL. After some research I learned that Thumbor supports these kind of URLs, but you first need to URI encode the entire source image path (so that it knows how to disambiguate its own arguments from the image path).

While I was here I also:
- got the tests running on ≥ Xcode 8 (!)
- updated the `README` with Cocoapods installation instructions and a Swift example
- a minor type improvement for improved Swift bridging (`id` to `instancetype`).