### PR TITLE
Dead-strip unused APIs for Fastly migration

### DIFF
--- a/thumborurl/ThumborURL.h
+++ b/thumborurl/ThumborURL.h
@@ -19,7 +19,7 @@
 
 typedef NS_ENUM(NSUInteger, TUFitInMode) {
     TUFitInNone = 0,
-//    TUFitInNormal,
+    TUFitInNormal,
 //    TUFitInAdaptive
 };
 

--- a/thumborurl/ThumborURL.h
+++ b/thumborurl/ThumborURL.h
@@ -83,7 +83,7 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 @property (nonatomic, assign) BOOL vflip;
 @property (nonatomic, assign) BOOL hflip;
 
-@property (nonatomic, copy) NSArray *filters;
+//@property (nonatomic, copy) NSArray *filters;
 
 @property (nonatomic, assign) CGFloat scale;
 
@@ -97,8 +97,8 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic, copy) NSArray *arguments;
 
-+ (id)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
-+ (id)filterWithName:(NSString *)name arguments:(id)firstArg, ... NS_REQUIRES_NIL_TERMINATION;
+//+ (id)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
+//+ (id)filterWithName:(NSString *)name arguments:(id)firstArg, ... NS_REQUIRES_NIL_TERMINATION;
 
 @end
 

--- a/thumborurl/ThumborURL.h
+++ b/thumborurl/ThumborURL.h
@@ -19,20 +19,20 @@
 
 typedef NS_ENUM(NSUInteger, TUFitInMode) {
     TUFitInNone = 0,
-    TUFitInNormal,
-    TUFitInAdaptive
+//    TUFitInNormal,
+//    TUFitInAdaptive
 };
 
 typedef NS_ENUM(NSUInteger, TUVerticalAlignment) {
     TUVerticalAlignMiddle = 0,
-    TUVerticalAlignTop,
-    TUVerticalAlignBottom,
+//    TUVerticalAlignTop,
+//    TUVerticalAlignBottom,
 };
 
 typedef NS_ENUM(NSUInteger, TUHorizontalAlignment) {
     TUHorizontalAlignCenter = 0,
-    TUHorizontalAlignLeft,
-    TUHorizontalAlignRight,
+//    TUHorizontalAlignLeft,
+//    TUHorizontalAlignRight,
 };
 
 typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
@@ -77,7 +77,6 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 @property (nonatomic, assign) CGRect crop;
 
 @property (nonatomic, assign) TUFitInMode fitIn;
-
 @property (nonatomic, assign) TUVerticalAlignment valign;
 @property (nonatomic, assign) TUHorizontalAlignment halign;
 

--- a/thumborurl/ThumborURL.h
+++ b/thumborurl/ThumborURL.h
@@ -13,26 +13,12 @@
 #import <Foundation/Foundation.h>
 
 
-@class TUFilter;
 @class TUOptions;
 
 
 typedef NS_ENUM(NSUInteger, TUFitInMode) {
     TUFitInNone = 0,
     TUFitInNormal,
-//    TUFitInAdaptive
-};
-
-typedef NS_ENUM(NSUInteger, TUVerticalAlignment) {
-    TUVerticalAlignMiddle = 0,
-//    TUVerticalAlignTop,
-//    TUVerticalAlignBottom,
-};
-
-typedef NS_ENUM(NSUInteger, TUHorizontalAlignment) {
-    TUHorizontalAlignCenter = 0,
-//    TUHorizontalAlignLeft,
-//    TUHorizontalAlignRight,
 };
 
 typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
@@ -70,20 +56,8 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 - (TUOptions *)optionsBySettingSize:(CGSize)newSize;
 
 @property (nonatomic, assign) CGSize targetSize;
-@property (nonatomic, assign) BOOL smart;
-@property (nonatomic, assign) BOOL trim;
-@property (nonatomic, assign) BOOL debug;
-@property (nonatomic, assign) BOOL meta;
-@property (nonatomic, assign) CGRect crop;
 
 @property (nonatomic, assign) TUFitInMode fitIn;
-@property (nonatomic, assign) TUVerticalAlignment valign;
-@property (nonatomic, assign) TUHorizontalAlignment halign;
-
-@property (nonatomic, assign) BOOL vflip;
-@property (nonatomic, assign) BOOL hflip;
-
-//@property (nonatomic, copy) NSArray *filters;
 
 @property (nonatomic, assign) CGFloat scale;
 
@@ -91,16 +65,6 @@ typedef NS_ENUM(NSUInteger, TUEncryptionMode) {
 
 @end
 
-
-@interface TUFilter : NSObject
-
-@property (nonatomic, copy) NSString *name;
-@property (nonatomic, copy) NSArray *arguments;
-
-//+ (id)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
-//+ (id)filterWithName:(NSString *)name arguments:(id)firstArg, ... NS_REQUIRES_NIL_TERMINATION;
-
-@end
 
 
 @interface NSURL (ThumborURL)

--- a/thumborurl/ThumborURL.m
+++ b/thumborurl/ThumborURL.m
@@ -256,18 +256,6 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
         [params addObject:@"smart"];
     }
 
-//    if (_filters.count) {
-//        NSMutableArray *filterStrings = [[NSMutableArray alloc] initWithCapacity:(_filters.count + 1)];
-//        [filterStrings addObject:@"filters"];
-//
-//        for (TUFilter *filter in _filters) {
-//            NSString *str = [[NSString alloc] initWithFormat:@"%@(%@)", filter.name, [filter.arguments componentsJoinedByString:@","]];
-//            [filterStrings addObject:str];
-//        }
-//
-//        [params addObject:[filterStrings componentsJoinedByString:@":"]];
-//    }
-
     return [params copy];
 }
 

--- a/thumborurl/ThumborURL.m
+++ b/thumborurl/ThumborURL.m
@@ -94,35 +94,6 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
 @end
 
 
-@implementation TUFilter
-
-//// TODO: what does this translate to for swift?
-//// TODO: can I take this API out?
-//+ (id)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
-//{
-//    TUFilter *filter = [[[self class] alloc] init];
-//    filter.arguments = arguments;
-//    filter.name = name;
-//    return filter;
-//}
-//
-//+ (id)filterWithName:(NSString *)name arguments:(id)firstArg, ...;
-//{
-//    NSMutableArray *argsAry = [NSMutableArray array];
-//
-//    va_list args;
-//    va_start(args, firstArg);
-//    for (id arg = firstArg; arg != nil; arg = va_arg(args, id)) {
-//        [argsAry addObject:arg];
-//    }
-//    va_end(args);
-//
-//    return [self filterWithName:name argumentsArray:argsAry];
-//}
-
-
-@end
-
 
 @implementation TUOptions
 
@@ -146,18 +117,8 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
     
     dispatch_once(&onceToken, ^{
         keys = @[
-            @"trim",
             @"targetSize",
-            @"smart",
-            @"debug",
-            @"meta", 
-            @"crop", 
             @"fitIn",
-            @"valign",
-            @"halign",
-//            @"filters",
-            @"vflip",
-            @"hflip",
             @"scale",
             @"encryption"
         ];
@@ -178,28 +139,8 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
 - (NSArray *)URLOptions;
 {
     NSMutableArray *params = [NSMutableArray array];
-    
-    if (_debug) {
-        [params addObject:@"debug"];
-    }
-
-    if (_meta) {
-        [params addObject:@"meta"];
-    }
-    
-    if (_trim) {
-        [params addObject:@"trim"];
-    }
-
-    if (!CGRectEqualToRect(_crop, CGRectZero)) {
-        [params addObject:TUFormattedStringFromRect(_crop)];
-    }
 
     switch (_fitIn) {
-//        case TUFitInAdaptive:
-//            [params addObject:@"adaptive-fit-in"];
-//            break;
-//
         case TUFitInNormal:
             [params addObject:@"fit-in"];
             break;
@@ -213,47 +154,8 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
     size.width *= _scale;
     size.height *= _scale;
 
-    if (_hflip) {
-        size.width *= -1.0f;
-    }
-    if (_vflip) {
-        size.height *= -1.0f;
-    }
-
     if (!CGSizeEqualToSize(size, CGSizeZero)) {
         [params addObject:TUFormattedStringFromSize(size)];
-    }
-
-    switch (_halign) {
-//        case TUHorizontalAlignLeft:
-//            [params addObject:@"left"];
-//            break;
-//
-//        case TUHorizontalAlignRight:
-//            [params addObject:@"right"];
-//            break;
-//
-        case TUHorizontalAlignCenter:
-            // Do nothing.
-            break;
-    }
-
-    switch (_valign) {
-//        case TUVerticalAlignTop:
-//            [params addObject:@"top"];
-//            break;
-//
-//        case TUVerticalAlignBottom:
-//            [params addObject:@"bottom"];
-//            break;
-//
-        case TUVerticalAlignMiddle:
-            // Do nothing.
-            break;
-    }
-
-    if (_smart) {
-        [params addObject:@"smart"];
     }
 
     return [params copy];

--- a/thumborurl/ThumborURL.m
+++ b/thumborurl/ThumborURL.m
@@ -194,14 +194,14 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
     }
 
     switch (_fitIn) {
-        case TUFitInAdaptive:
-            [params addObject:@"adaptive-fit-in"];
-            break;
-            
-        case TUFitInNormal:
-            [params addObject:@"fit-in"];
-            break;
-            
+//        case TUFitInAdaptive:
+//            [params addObject:@"adaptive-fit-in"];
+//            break;
+//
+//        case TUFitInNormal:
+//            [params addObject:@"fit-in"];
+//            break;
+
         case TUFitInNone:
             // Do nothing.
             break;
@@ -223,28 +223,28 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
     }
 
     switch (_halign) {
-        case TUHorizontalAlignLeft:
-            [params addObject:@"left"];
-            break;
-            
-        case TUHorizontalAlignRight:
-            [params addObject:@"right"];
-            break;
-            
+//        case TUHorizontalAlignLeft:
+//            [params addObject:@"left"];
+//            break;
+//
+//        case TUHorizontalAlignRight:
+//            [params addObject:@"right"];
+//            break;
+//
         case TUHorizontalAlignCenter:
             // Do nothing.
             break;
     }
 
     switch (_valign) {
-        case TUVerticalAlignTop:
-            [params addObject:@"top"];
-            break;
-            
-        case TUVerticalAlignBottom:
-            [params addObject:@"bottom"];
-            break;
-            
+//        case TUVerticalAlignTop:
+//            [params addObject:@"top"];
+//            break;
+//
+//        case TUVerticalAlignBottom:
+//            [params addObject:@"bottom"];
+//            break;
+//
         case TUVerticalAlignMiddle:
             // Do nothing.
             break;

--- a/thumborurl/ThumborURL.m
+++ b/thumborurl/ThumborURL.m
@@ -200,9 +200,9 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
 //            [params addObject:@"adaptive-fit-in"];
 //            break;
 //
-//        case TUFitInNormal:
-//            [params addObject:@"fit-in"];
-//            break;
+        case TUFitInNormal:
+            [params addObject:@"fit-in"];
+            break;
 
         case TUFitInNone:
             // Do nothing.

--- a/thumborurl/ThumborURL.m
+++ b/thumborurl/ThumborURL.m
@@ -96,27 +96,29 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
 
 @implementation TUFilter
 
-+ (id)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
-{
-    TUFilter *filter = [[[self class] alloc] init];
-    filter.arguments = arguments;
-    filter.name = name;
-    return filter;
-}
-
-+ (id)filterWithName:(NSString *)name arguments:(id)firstArg, ...;
-{
-    NSMutableArray *argsAry = [NSMutableArray array];
-    
-    va_list args;
-    va_start(args, firstArg);
-    for (id arg = firstArg; arg != nil; arg = va_arg(args, id)) {
-        [argsAry addObject:arg];
-    }
-    va_end(args);
-    
-    return [self filterWithName:name argumentsArray:argsAry];
-}
+//// TODO: what does this translate to for swift?
+//// TODO: can I take this API out?
+//+ (id)filterWithName:(NSString *)name argumentsArray:(NSArray *)arguments;
+//{
+//    TUFilter *filter = [[[self class] alloc] init];
+//    filter.arguments = arguments;
+//    filter.name = name;
+//    return filter;
+//}
+//
+//+ (id)filterWithName:(NSString *)name arguments:(id)firstArg, ...;
+//{
+//    NSMutableArray *argsAry = [NSMutableArray array];
+//
+//    va_list args;
+//    va_start(args, firstArg);
+//    for (id arg = firstArg; arg != nil; arg = va_arg(args, id)) {
+//        [argsAry addObject:arg];
+//    }
+//    va_end(args);
+//
+//    return [self filterWithName:name argumentsArray:argsAry];
+//}
 
 
 @end
@@ -152,8 +154,8 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
             @"crop", 
             @"fitIn",
             @"valign",
-            @"halign", 
-            @"filters",
+            @"halign",
+//            @"filters",
             @"vflip",
             @"hflip",
             @"scale",
@@ -254,17 +256,17 @@ static inline NSData *TUCreateEncryptedHMACSHA1Data(NSString *imageURLString, NS
         [params addObject:@"smart"];
     }
 
-    if (_filters.count) {
-        NSMutableArray *filterStrings = [[NSMutableArray alloc] initWithCapacity:(_filters.count + 1)];
-        [filterStrings addObject:@"filters"];
-
-        for (TUFilter *filter in _filters) {
-            NSString *str = [[NSString alloc] initWithFormat:@"%@(%@)", filter.name, [filter.arguments componentsJoinedByString:@","]];
-            [filterStrings addObject:str];
-        }
-
-        [params addObject:[filterStrings componentsJoinedByString:@":"]];
-    }
+//    if (_filters.count) {
+//        NSMutableArray *filterStrings = [[NSMutableArray alloc] initWithCapacity:(_filters.count + 1)];
+//        [filterStrings addObject:@"filters"];
+//
+//        for (TUFilter *filter in _filters) {
+//            NSString *str = [[NSString alloc] initWithFormat:@"%@(%@)", filter.name, [filter.arguments componentsJoinedByString:@","]];
+//            [filterStrings addObject:str];
+//        }
+//
+//        [params addObject:[filterStrings componentsJoinedByString:@":"]];
+//    }
 
     return [params copy];
 }


### PR DESCRIPTION
As part of migrating to Fastly, pull unused Thumbor APIs out of the codebase so we don't gain any new clients.

Note the target base branch is not master, it's a fork of 0.0.4 that we'll consume.